### PR TITLE
feat: support attachments for all record types

### DIFF
--- a/src/components/UploadButton.jsx
+++ b/src/components/UploadButton.jsx
@@ -1,14 +1,26 @@
 import { useRef, useState } from 'react';
-import { uploadRepairAttachment, getSignedUrl } from '../features/storage';
+import {
+  uploadInspectionAttachment,
+  uploadCitationAttachment,
+  uploadRepairAttachment,
+  getSignedUrl
+} from '../features/storage';
 
-export default function UploadButton() {
+export default function UploadButton({ type = 'repairs' }) {
   const inputRef = useRef();
   const [lastPath, setLastPath] = useState(null);
+
+  const uploaders = {
+    inspections: uploadInspectionAttachment,
+    citations: uploadCitationAttachment,
+    repairs: uploadRepairAttachment
+  };
 
   async function handleUpload(e) {
     const file = e.target.files?.[0];
     if (!file) return;
-    const path = await uploadRepairAttachment(file);
+    const uploader = uploaders[type] || uploaders.repairs;
+    const path = await uploader(file);
     setLastPath(path);
     alert('Uploaded to: ' + path);
   }

--- a/src/features/storage.js
+++ b/src/features/storage.js
@@ -1,10 +1,12 @@
 import { supabase } from '../lib/supabase';
 
-export async function uploadRepairAttachment(file) {
-  const { data: { user } } = await supabase.auth.getUser();
+async function uploadAttachment(kind, file) {
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');
 
-  const path = `user/${user.id}/repairs/${crypto.randomUUID()}-${file.name}`;
+  const path = `user/${user.id}/${kind}/${crypto.randomUUID()}-${file.name}`;
   const { data, error } = await supabase.storage
     .from('attachments')
     .upload(path, file, { upsert: false });
@@ -12,6 +14,13 @@ export async function uploadRepairAttachment(file) {
   if (error) throw error;
   return data.path; // store this string if you want to reference it later
 }
+
+export const uploadInspectionAttachment = file =>
+  uploadAttachment('inspections', file);
+export const uploadCitationAttachment = file =>
+  uploadAttachment('citations', file);
+export const uploadRepairAttachment = file =>
+  uploadAttachment('repairs', file);
 
 export async function getSignedUrl(path, expiresIn = 60) {
   const { data, error } = await supabase.storage


### PR DESCRIPTION
## Summary
- allow uploading attachments for inspections, citations, and repairs via new storage helpers
- update UploadButton to choose attachment type through a prop

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a73d08bfec8329ac8e3457c574637a