### PR TITLE
feat: sync chassis data across users with supabase

### DIFF
--- a/src/features/chassis.js
+++ b/src/features/chassis.js
@@ -1,0 +1,29 @@
+import { supabase } from '../lib/supabase';
+
+export async function fetchChassis() {
+  const { data, error } = await supabase
+    .from('chassis')
+    .select('*')
+    .order('unit');
+  if (error) throw error;
+  return data;
+}
+
+export async function upsertChassis(rows) {
+  const payload = Array.isArray(rows) ? rows : [rows];
+  const { error } = await supabase.from('chassis').upsert(payload);
+  if (error) throw error;
+}
+
+export async function deleteChassis(id) {
+  const { error } = await supabase.from('chassis').delete().eq('id', id);
+  if (error) throw error;
+}
+
+export function onChassisChange(callback) {
+  const channel = supabase
+    .channel('public:chassis')
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'chassis' }, callback)
+    .subscribe();
+  return channel;
+}


### PR DESCRIPTION
## Summary
- load chassis data from Supabase and subscribe to real-time updates
- persist edits, imports, and deletions back to Supabase using new helper functions
- add Supabase chassis feature module

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a740ba9cfc8329a183d1d341fcb9f2