### PR TITLE
Persist chassis data locally

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -109,14 +109,28 @@ export default function App(){
   const { loading } = useAuth();
 
   // data
-  const [items, setItems] = useState([]);
+  const STORAGE_KEY = "chassis-items";
+  const [items, setItems] = useState(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : [];
+    } catch {
+      return [];
+    }
+  });
+  const hasLocalItems = useRef(items.length > 0);
   const [ledger, setLedger] = useState({});
 
   // load shared chassis data and subscribe to changes
   useEffect(() => {
     fetchChassis()
-      .then((data) => setItems(data.length ? data : DEMO))
-      .catch(() => setItems(DEMO));
+      .then((data) => {
+        if (data.length) setItems(data);
+        else if (!hasLocalItems.current) setItems(DEMO);
+      })
+      .catch(() => {
+        if (!hasLocalItems.current) setItems(DEMO);
+      });
     const channel = onChassisChange(({ eventType, new: newRow, old }) => {
       setItems((prev) => {
         if (eventType === "INSERT") return [newRow, ...prev];
@@ -131,6 +145,11 @@ export default function App(){
       channel.unsubscribe();
     };
   }, []);
+
+  // persist chassis locally
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  }, [items]);
 
   // load shared ledger data and subscribe to changes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- load chassis list from localStorage on start and fall back to demo data when empty
- save chassis list to localStorage on every change

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a746721c8483299d645ad0d5df724e