### PR TITLE
Show alert on upsert errors

### DIFF
--- a/src/features/chassis.js
+++ b/src/features/chassis.js
@@ -12,7 +12,10 @@ export async function fetchChassis() {
 export async function upsertChassis(rows) {
   const payload = Array.isArray(rows) ? rows : [rows];
   const { error } = await supabase.from('chassis').upsert(payload);
-  if (error) throw error;
+  if (error) {
+    alert('Failed to save chassis: ' + error.message);
+    throw error;
+  }
 }
 
 export async function deleteChassis(id) {

--- a/src/features/ledger.js
+++ b/src/features/ledger.js
@@ -23,7 +23,10 @@ export async function upsertLedgerRow(chassisId, bucket) {
     repairs: bucket.repairs || [],
     inspections: bucket.inspections || { annual: [], bit: [] },
   });
-  if (error) throw error;
+  if (error) {
+    alert('Failed to save inspections/citations/repairs: ' + error.message);
+    throw error;
+  }
 }
 
 export function onLedgerChange(callback) {


### PR DESCRIPTION
## Summary
- pop up a browser alert if saving chassis records fails
- pop up a browser alert if saving ledger data fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a74be7af008329b234fae98c43b43d