### PR TITLE
Bind ledger delete actions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -909,7 +909,6 @@ function LedgerDrawer({
                 String(linkedCount[e.id] || 0),
                 e.id
               ])}
-              // FIX: call the prop directly (it's already bound to chassisId)
               onDelete={deleteCitation}
               emptyText="No citations yet."
             />
@@ -982,7 +981,6 @@ function LedgerDrawer({
                   e.id
                 ];
               })}
-              // FIX: call the prop directly (it's already bound to chassisId)
               onDelete={deleteRepair}
               emptyText="No repairs yet."
             />

--- a/src/features/chassis.js
+++ b/src/features/chassis.js
@@ -1,16 +1,45 @@
 import { supabase } from '../lib/supabase';
 
+const COLUMN_MAP = {
+  id: 'id',
+  unit: 'unit',
+  plate: 'plate',
+  vin: 'vin',
+  registrationDue: 'registration_due',
+  annualDue: 'annual_due',
+  bitDue: 'bit_due',
+  notes: 'notes'
+};
+
+function fromDb(row) {
+  const out = {};
+  for (const [camel, snake] of Object.entries(COLUMN_MAP)) {
+    if (row[snake] !== undefined) out[camel] = row[snake];
+  }
+  return out;
+}
+
+function toDb(row) {
+  const out = {};
+  for (const [camel, snake] of Object.entries(COLUMN_MAP)) {
+    if (row[camel] !== undefined) out[snake] = row[camel];
+  }
+  return out;
+}
+
 export async function fetchChassis() {
+  const columns = Object.values(COLUMN_MAP).join(',');
   const { data, error } = await supabase
     .from('chassis')
-    .select('*')
+    .select(columns)
     .order('unit');
   if (error) throw error;
-  return data;
+  return data.map(fromDb);
 }
 
 export async function upsertChassis(rows) {
-  const payload = Array.isArray(rows) ? rows : [rows];
+  const list = Array.isArray(rows) ? rows : [rows];
+  const payload = list.map(toDb);
   const { error } = await supabase.from('chassis').upsert(payload);
   if (error) {
     alert('Failed to save chassis: ' + error.message);
@@ -26,7 +55,10 @@ export async function deleteChassis(id) {
 export function onChassisChange(callback) {
   const channel = supabase
     .channel('public:chassis')
-    .on('postgres_changes', { event: '*', schema: 'public', table: 'chassis' }, callback)
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'chassis' }, payload => {
+      const wrap = obj => (obj ? fromDb(obj) : obj);
+      callback({ eventType: payload.eventType, new: wrap(payload.new), old: wrap(payload.old) });
+    })
     .subscribe();
   return channel;
 }


### PR DESCRIPTION
## Summary
- translate chassis fields between camelCase and snake_case to match Supabase schema
- convert realtime chassis update payloads to camelCase so all clients reflect changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a74e2b3b2c8329a3048d2547c59111